### PR TITLE
obselete reference to template.css removed

### DIFF
--- a/pages/template.html
+++ b/pages/template.html
@@ -5,7 +5,6 @@
   <meta charset="utf-8">
   <link rel="stylesheet" href="../css/bootstrap.css">
   <link rel="stylesheet" href="../css/master.css">
-  <link rel="stylesheet" href="../css/template.css">
 
   <title>The Little Green Larder</title>
 </head>


### PR DESCRIPTION
This was suggested in the last pull request